### PR TITLE
Data too long for column 'shipping_zip'

### DIFF
--- a/config/shopify.php
+++ b/config/shopify.php
@@ -181,6 +181,7 @@ return [
             'shipping_address1' => 128,
             'shipping_address2' => 128,
             'gateway' => 32,
+            'shipping_zip' => 32,
         ],
         'map_updatable' => '*',
         'model' => \Dan\Shopify\Laravel\Models\Order::class,


### PR DESCRIPTION
Fixes https://github.com/ShineOnCom/shopify-app-issues/issues/2998